### PR TITLE
phyton strings turned into python

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -262,7 +262,7 @@
       "needsContribution": false,
       "technologies": [
         "Go",
-        "Phyton",
+        "Python",
         "JavaScript"
       ]
     },
@@ -608,7 +608,7 @@
       ],
       "needsContribution": false,
       "technologies": [
-        "Phyton"
+        "Python"
       ]
     },
     {
@@ -622,7 +622,7 @@
       ],
       "needsContribution": false,
       "technologies": [
-        "Phyton"
+        "Python"
       ]
     },
     {


### PR DESCRIPTION
###  <ins> What Changed? </ins>
- **A minor typo fix:** Three strings which includes _Phyton_ word in it at `projects.json` file just turned into _Python_  words instead.