### PR TITLE
Missing comma in projects json

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -830,7 +830,7 @@
       "technologies": [
         "JavaScript"
       ]
-    }
+    },
     {
       "name": "turkish-id-checker",
       "url": "https://github.com/kaangokdemir/turkish-id-checker",


### PR DESCRIPTION
## What Changed? 
- Looks like merging two branch in once caused a missing comma in `projects.json` file which caused https://acik-kaynak.org/lists/projects/ to not working properly since 6 days.